### PR TITLE
Add support for costmap 3d

### DIFF
--- a/mbf_abstract_nav/src/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_controller_execution.cpp
@@ -270,7 +270,7 @@ namespace mbf_abstract_nav
     {
       while (moving_ && ros::ok())
       {
-        boost::chrono::thread_clock::time_point loop_start_time = boost::chrono::thread_clock::now();
+        boost::chrono::steady_clock::time_point loop_start_time = boost::chrono::steady_clock::now();
 
         if (cancel_)
         {
@@ -376,7 +376,7 @@ namespace mbf_abstract_nav
           }
         }
 
-        boost::chrono::thread_clock::time_point end_time = boost::chrono::thread_clock::now();
+        boost::chrono::steady_clock::time_point end_time = boost::chrono::steady_clock::now();
         boost::chrono::microseconds execution_duration =
             boost::chrono::duration_cast<boost::chrono::microseconds>(end_time - loop_start_time);
         configuration_mutex_.lock();

--- a/mbf_costmap_nav/CMakeLists.txt
+++ b/mbf_costmap_nav/CMakeLists.txt
@@ -1,9 +1,12 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(mbf_costmap_nav)
 
+set(CMAKE_CXX_STANDARD 11)
+
 find_package(catkin REQUIRED
   COMPONENTS
   base_local_planner
+  costmap_3d
   dynamic_reconfigure
   geometry_msgs
   mbf_abstract_nav
@@ -36,6 +39,7 @@ catkin_package(
   actionlib
   actionlib_msgs
   base_local_planner
+  costmap_3d
   dynamic_reconfigure
   geometry_msgs
   mbf_abstract_nav
@@ -71,6 +75,7 @@ target_link_libraries(${MBF_NAV_CORE_WRAPPER_LIB}
 
 add_library(${MBF_COSTMAP_2D_SERVER_LIB}
   src/mbf_costmap_nav/costmap_navigation_server.cpp
+  src/mbf_costmap_nav/costmap_3d_navigation_server.cpp
   src/mbf_costmap_nav/costmap_planner_execution.cpp
   src/mbf_costmap_nav/costmap_controller_execution.cpp
   src/mbf_costmap_nav/costmap_recovery_execution.cpp

--- a/mbf_costmap_nav/include/mbf_costmap_nav/costmap_3d_navigation_server.h
+++ b/mbf_costmap_nav/include/mbf_costmap_nav/costmap_3d_navigation_server.h
@@ -30,7 +30,7 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  *
- *  move_base_server_node.cpp
+ *  costmap_navigation_server.h
  *
  *  authors:
  *    Sebastian Pütz <spuetz@uni-osnabrueck.de>
@@ -38,53 +38,45 @@
  *
  */
 
-#include "mbf_costmap_nav/costmap_navigation_server.h"
-#include "mbf_costmap_nav/costmap_3d_navigation_server.h"
-#include <signal.h>
-#include <mbf_utility/types.h>
-#include <tf2_ros/transform_listener.h>
+#ifndef MBF_COSTMAP_NAV__COSTMAP_3D_NAVIGATION_SERVER_H_
+#define MBF_COSTMAP_NAV__COSTMAP_3D_NAVIGATION_SERVER_H_
 
-typedef boost::shared_ptr<mbf_costmap_nav::CostmapNavigationServer> CostmapNavigationServerPtr;
-mbf_costmap_nav::CostmapNavigationServer::Ptr costmap_nav_srv_ptr;
+#include "costmap_navigation_server.h"
+#include <costmap_3d/costmap_3d_ros.h>
 
-void sigintHandler(int sig)
+namespace mbf_costmap_nav
 {
-  ROS_INFO_STREAM("Shutdown costmap navigation server.");
-  if(costmap_nav_srv_ptr)
-  {
-    costmap_nav_srv_ptr->stop();
-  }
-  ros::shutdown();
-}
+/**
+ * @defgroup move_base_server Move Base Server using a 3D Costmap
+ * @brief Classes belonging to the Move Base Server level.
+ */
 
-int main(int argc, char **argv)
+
+/**
+ * @brief The Costmap3DNavigationServer extends the CostmapNavigationServer to use 3D costmaps.
+ *
+ * @ingroup navigation_server move_base_server
+ */
+class Costmap3DNavigationServer : public CostmapNavigationServer
 {
-  ros::init(argc, argv, "mbf_2d_nav_server", ros::init_options::NoSigintHandler);
+public:
 
-  ros::NodeHandle nh;
-  ros::NodeHandle private_nh("~");
+  typedef boost::shared_ptr<costmap_3d::Costmap3DROS> Costmap3DPtr;
 
-  double cache_time;
-  private_nh.param("tf_cache_time", cache_time, 10.0);
+  typedef boost::shared_ptr<Costmap3DNavigationServer> Ptr;
 
-  bool use_costmap_3d;
-  private_nh.param("use_costmap_3d", use_costmap_3d, false);
+  /**
+   * @brief Constructor
+   * @param tf_listener_ptr Shared pointer to a common TransformListener
+   */
+  Costmap3DNavigationServer(const TFPtr &tf_listener_ptr);
 
-  signal(SIGINT, sigintHandler);
-#ifdef USE_OLD_TF
-  TFPtr tf_listener_ptr(new TF(nh, ros::Duration(cache_time), true));
-#else
-  TFPtr tf_listener_ptr(new TF(ros::Duration(cache_time)));
-  tf2_ros::TransformListener tf_listener(*tf_listener_ptr);
-#endif
-  if (use_costmap_3d)
-  {
-    costmap_nav_srv_ptr = boost::make_shared<mbf_costmap_nav::Costmap3DNavigationServer>(tf_listener_ptr);
-  }
-  else
-  {
-    costmap_nav_srv_ptr = boost::make_shared<mbf_costmap_nav::CostmapNavigationServer>(tf_listener_ptr);
-  }
-  ros::spin();
-  return EXIT_SUCCESS;
-}
+  /**
+   * @brief Destructor
+   */
+  virtual ~Costmap3DNavigationServer();
+};
+
+} /* namespace mbf_costmap_nav */
+
+#endif /* MBF_COSTMAP_NAV__COSTMAP_3D_NAVIGATION_SERVER_H_ */

--- a/mbf_costmap_nav/include/mbf_costmap_nav/costmap_navigation_server.h
+++ b/mbf_costmap_nav/include/mbf_costmap_nav/costmap_navigation_server.h
@@ -85,8 +85,12 @@ public:
   /**
    * @brief Constructor
    * @param tf_listener_ptr Shared pointer to a common TransformListener
+   * @param global_costmap_ptr Optional shared pointer to the global costmap
+   * @param local_costmap_ptr Optional shared pointer to the local costmap
    */
-  CostmapNavigationServer(const TFPtr &tf_listener_ptr);
+  CostmapNavigationServer(const TFPtr &tf_listener_ptr,
+                          const CostmapPtr &global_costmap_ptr = CostmapPtr(),
+                          const CostmapPtr &local_costmap_ptr = CostmapPtr());
 
   /**
    * @brief Destructor

--- a/mbf_costmap_nav/package.xml
+++ b/mbf_costmap_nav/package.xml
@@ -20,6 +20,7 @@
     <build_depend>actionlib</build_depend>
     <build_depend>actionlib_msgs</build_depend>
     <build_depend>base_local_planner</build_depend>
+    <build_depend>costmap_3d</build_depend>
     <build_depend>dynamic_reconfigure</build_depend>
     <build_depend>std_msgs</build_depend>
     <build_depend>std_srvs</build_depend>
@@ -37,6 +38,7 @@
     <run_depend>actionlib</run_depend>
     <run_depend>actionlib_msgs</run_depend>
     <run_depend>base_local_planner</run_depend>
+    <run_depend>costmap_3d</run_depend>
     <run_depend>dynamic_reconfigure</run_depend>
     <run_depend>std_msgs</run_depend>
     <run_depend>std_srvs</run_depend>

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_controller_execution.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_controller_execution.cpp
@@ -96,7 +96,8 @@ bool CostmapControllerExecution::isSafeToDrive()
   // Check that the observation buffers for the costmap are current, we don't want to drive blind
   if (!costmap_ptr_->isCurrent())
   {
-    ROS_WARN("Sensor data is out of date, we're not going to allow commanding of the base for safety");
+    ROS_WARN_STREAM("Sensor data for costmap \"" << costmap_ptr_->getName()
+                    << "\" is out of date, we're not going to allow commanding of the base for safety");
     return false;
   }
   return true;

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_navigation_server.cpp
@@ -54,8 +54,9 @@
 namespace mbf_costmap_nav
 {
 
-
-CostmapNavigationServer::CostmapNavigationServer(const TFPtr &tf_listener_ptr) :
+CostmapNavigationServer::CostmapNavigationServer(const TFPtr &tf_listener_ptr,
+                                                 const CostmapPtr &global_costmap_ptr,
+                                                 const CostmapPtr &local_costmap_ptr) :
   AbstractNavigationServer(tf_listener_ptr),
   recovery_plugin_loader_("mbf_costmap_core", "mbf_costmap_core::CostmapRecovery"),
   nav_core_recovery_plugin_loader_("nav_core", "nav_core::RecoveryBehavior"),
@@ -63,10 +64,19 @@ CostmapNavigationServer::CostmapNavigationServer(const TFPtr &tf_listener_ptr) :
   nav_core_controller_plugin_loader_("nav_core", "nav_core::BaseLocalPlanner"),
   planner_plugin_loader_("mbf_costmap_core", "mbf_costmap_core::CostmapPlanner"),
   nav_core_planner_plugin_loader_("nav_core", "nav_core::BaseGlobalPlanner"),
-  global_costmap_ptr_(new costmap_2d::Costmap2DROS("global_costmap", *tf_listener_ptr_)),
-  local_costmap_ptr_(new costmap_2d::Costmap2DROS("local_costmap", *tf_listener_ptr_)),
+  global_costmap_ptr_(global_costmap_ptr),
+  local_costmap_ptr_(local_costmap_ptr),
   setup_reconfigure_(false), shutdown_costmaps_(false)
 {
+  if (!global_costmap_ptr_)
+  {
+    global_costmap_ptr_.reset(new costmap_2d::Costmap2DROS("global_costmap", *tf_listener_ptr_));
+  }
+  if (!local_costmap_ptr_)
+  {
+    local_costmap_ptr_.reset(new costmap_2d::Costmap2DROS("local_costmap", *tf_listener_ptr_));
+  }
+
   // even if shutdown_costmaps is a dynamically reconfigurable parameter, we
   // need it here to decide whether to start or not the costmaps on starting up
   private_nh_.param("shutdown_costmaps", shutdown_costmaps_, false);


### PR DESCRIPTION
Add the ability to use costmap 3d for costmaps in place of costmap 2d, based on a parameter.

Clearly, the costmap 3d code in navigation must be merged in first!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/move_base_flex/2)
<!-- Reviewable:end -->
