### PR TITLE
On controller execution, check that local costmap is current

### DIFF
--- a/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
+++ b/mbf_abstract_nav/include/mbf_abstract_nav/abstract_controller_execution.h
@@ -240,11 +240,20 @@ namespace mbf_abstract_nav
      */
     virtual void run();
 
+    /**
+     * @brief Check if its safe to drive.
+     * This method gets called at every controller cycle, stopping the robot if its not. When overridden by
+     * child class, gives a chance to the specific execution implementation to stop the robot if it detects
+     * something wrong on the underlying map.
+     * @return Always true, unless overridden by child class.
+     */
+    virtual bool isSafeToDrive() { return true; };
+
   private:
 
 
     /**
-     * publishes a velocity command with zero values to stop the robot.
+     * @brief Publishes a velocity command with zero values to stop the robot.
      */
     void publishZeroVelocity();
 

--- a/mbf_abstract_nav/src/abstract_controller_execution.cpp
+++ b/mbf_abstract_nav/src/abstract_controller_execution.cpp
@@ -272,11 +272,20 @@ namespace mbf_abstract_nav
       {
         boost::chrono::thread_clock::time_point loop_start_time = boost::chrono::thread_clock::now();
 
-        if(cancel_){
+        if (cancel_)
+        {
           setState(CANCELED);
           condition_.notify_all();
           moving_ = false;
           return;
+        }
+
+        if (!isSafeToDrive())
+        {
+          // the specific implementation must have detected a risk situation; at this abstract level, we
+          // cannot tell what the problem is, but anyway we command the robot to stop to avoid crashes
+          publishZeroVelocity();   // note that we still feedback command calculated by the plugin
+          boost::this_thread::sleep_for(calling_duration_);
         }
 
         // update plan dynamically
@@ -294,7 +303,7 @@ namespace mbf_abstract_nav
           }
 
           // check if plan could be set
-          if(!controller_->setPlan(plan))
+          if (!controller_->setPlan(plan))
           {
             setState(INVALID_PLAN);
             condition_.notify_all();

--- a/mbf_costmap_nav/include/mbf_costmap_nav/costmap_controller_execution.h
+++ b/mbf_costmap_nav/include/mbf_costmap_nav/costmap_controller_execution.h
@@ -86,6 +86,14 @@ public:
 protected:
 
   /**
+   * @brief Check if its safe to drive.
+   * This method overrides abstract execution empty implementation with underlying map specific check,
+   * more precisely if controller costmap is current.
+   * @return True if costmap is current, false otherwise.
+   */
+  bool isSafeToDrive();
+
+  /**
    * @brief Request plugin for a new velocity command. We override this method so we can lock the local costmap
    *        before calling the planner.
    * @param pose the current pose of the robot.

--- a/mbf_costmap_nav/src/mbf_costmap_nav/costmap_controller_execution.cpp
+++ b/mbf_costmap_nav/src/mbf_costmap_nav/costmap_controller_execution.cpp
@@ -91,4 +91,15 @@ uint32_t CostmapControllerExecution::computeVelocityCmd(
   return controller_->computeVelocityCommands(robot_pose, robot_velocity, vel_cmd, message);
 }
 
+bool CostmapControllerExecution::isSafeToDrive()
+{
+  // Check that the observation buffers for the costmap are current, we don't want to drive blind
+  if (!costmap_ptr_->isCurrent())
+  {
+    ROS_WARN("Sensor data is out of date, we're not going to allow commanding of the base for safety");
+    return false;
+  }
+  return true;
+}
+
 } /* namespace mbf_costmap_nav */


### PR DESCRIPTION
Cherry pick of upstream commit to only drive when costmap is current.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/move_base_flex/3)
<!-- Reviewable:end -->
