### PR TITLE
fix crashes on exit by making exit safe

### DIFF
--- a/mbf_costmap_nav/src/move_base_server_node.cpp
+++ b/mbf_costmap_nav/src/move_base_server_node.cpp
@@ -44,17 +44,9 @@
 #include <mbf_utility/types.h>
 #include <tf2_ros/transform_listener.h>
 
-typedef boost::shared_ptr<mbf_costmap_nav::CostmapNavigationServer> CostmapNavigationServerPtr;
-mbf_costmap_nav::CostmapNavigationServer::Ptr costmap_nav_srv_ptr;
-
 void sigintHandler(int sig)
 {
-  ROS_INFO_STREAM("Shutdown costmap navigation server.");
-  if(costmap_nav_srv_ptr)
-  {
-    costmap_nav_srv_ptr->stop();
-  }
-  ros::shutdown();
+  ros::requestShutdown();
 }
 
 int main(int argc, char **argv)
@@ -77,6 +69,7 @@ int main(int argc, char **argv)
   TFPtr tf_listener_ptr(new TF(ros::Duration(cache_time)));
   tf2_ros::TransformListener tf_listener(*tf_listener_ptr);
 #endif
+  boost::shared_ptr<mbf_costmap_nav::CostmapNavigationServer> costmap_nav_srv_ptr;
   if (use_costmap_3d)
   {
     costmap_nav_srv_ptr = boost::make_shared<mbf_costmap_nav::Costmap3DNavigationServer>(tf_listener_ptr);
@@ -86,5 +79,6 @@ int main(int argc, char **argv)
     costmap_nav_srv_ptr = boost::make_shared<mbf_costmap_nav::CostmapNavigationServer>(tf_listener_ptr);
   }
   ros::spin();
+  costmap_nav_srv_ptr->stop();
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
The costmap nav server pointer was global and therefore could be
destroyed after certain global ROS objects (like the timer manager)
are already destroyed. This was causing crashes on exit. Fix this by
moving the pointer into the main function.

Also, ros::shutdown() was being used in the signal handler, which is
unsafe because it grabs a lock (the signal could be delivered while
the lock was held in the thread it was handled in). This was replaced
with the signal handler safe ros::requestShutdown().

There is still a mess with the plugins on exit where the plugins are
unloaded before the instances that were created from them have been
deleted. Pluginlib handles this OK by emitting a loud warning. The
plugin issue will be fixed in a later commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/move_base_flex/4)
<!-- Reviewable:end -->
