### PR TITLE
package.xml: Remove depencency on move_base

### DIFF
--- a/mbf_costmap_nav/package.xml
+++ b/mbf_costmap_nav/package.xml
@@ -51,8 +51,9 @@
     <run_depend>geometry_msgs</run_depend>
 
     <!-- Required by the backward compatibility move_base relay -->
-    <run_depend>move_base_msgs</run_depend>
-    <run_depend>move_base</run_depend>
+    <!-- Badger remove these to speed up build time since we don't use the relay -->
+    <!--<run_depend>move_base_msgs</run_depend>-->
+    <!--<run_depend>move_base</run_depend>-->
 
     <export>
       <rosdoc config="rosdoc.yaml" />


### PR DESCRIPTION
This is required only for the move_base relay, which Badger doesn't use.
Removing this prevents us from having to build move_base, which speeds
up our build times.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/move_base_flex/5)
<!-- Reviewable:end -->
