### PR TITLE
server node: use MultiThreadedSpinner

### DIFF
--- a/mbf_costmap_nav/src/move_base_server_node.cpp
+++ b/mbf_costmap_nav/src/move_base_server_node.cpp
@@ -62,6 +62,8 @@ int main(int argc, char **argv)
   private_nh.param("tf_cache_time", cache_time, 10.0);
   bool use_costmap_3d;
   private_nh.param("use_costmap_3d", use_costmap_3d, false);
+  int thread_count;
+  private_nh.param("thread_count", thread_count, 0);
 
   signal(SIGINT, sigintHandler);
 #ifdef USE_OLD_TF
@@ -82,7 +84,16 @@ int main(int argc, char **argv)
     costmap_nav_srv_ptr = boost::make_shared<
       mbf_costmap_nav::CostmapNavigationServer<costmap_2d::Costmap2DROS>>(tf_listener_ptr);
   }
-  ros::spin();
+  // Negative thread count, means just use a single thread
+  if (thread_count < 0)
+  {
+    ros::spin();
+  }
+  else
+  {
+    ros::MultiThreadedSpinner spinner(thread_count);
+    spinner.spin();
+  }
 
   if (costmap_nav_srv_ptr)
   {


### PR DESCRIPTION
Add a new optional parameter, thread_count, to use as the number of threads to pass to the new MultiThreadedSpinner. The thread_count defaults to 0, which means one thread per core. A negative thread_count means to go back to the old single-threaded spin(). A positive thread_count means to spin a multi-threaded spinner with that number of threads.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BadgerTechnologies/move_base_flex/7)
<!-- Reviewable:end -->
